### PR TITLE
Fit boundaries on init

### DIFF
--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -130,6 +130,8 @@
 
 				this.setLocations();
 
+				this.fitBounds();
+
 				this.activateIconSelect();
 
 				if ( this.settings.drawingManager && this.settings.editable )
@@ -721,6 +723,38 @@
 
 				}
 
+			},
+
+			fitBounds: function () {
+				var bounds = new google.maps.LatLngBounds();
+				var hasBounds = false;
+
+				for ( var key in this.mapObjects ) {
+					var mapObject = this.mapObjects[key];
+					
+					if ( 
+						mapObject instanceof google.maps.Circle ||
+						mapObject instanceof google.maps.Rectangle
+					) {
+						bounds.union(mapObject.getBounds());
+						hasBounds = true;
+					}
+
+					if (mapObject instanceof google.maps.Polygon) {
+						mapObject.getPaths().forEach(function(path) {
+							path.forEach(function(latLng) {
+								bounds.extend(latLng);
+							});
+						});
+						hasBounds = true;
+					}
+
+				}
+
+				if (hasBounds) {
+					this.map.fitBounds(bounds);
+					this.map.setCenter(bounds.getCenter());
+				}
 			},
 
 			contextmenu: function(latLng, pixel) {


### PR DESCRIPTION
You might not want to use this but figured I'd share.  I didn't add support for markers & polylines since I've removed them based on my use case but I noticed that the map always resets to the default bounding when editing which could be confusing if the actual contents is out of view.  This resolves that but fitting the boundaries.  Markers and polylines probably aren't hard to add to this -- I just didn't have time to test.